### PR TITLE
Adding linux version of event hub diagnostics

### DIFF
--- a/Templates/LinuxDiagnosticswithEventHubs/azuredeploy.json
+++ b/Templates/LinuxDiagnosticswithEventHubs/azuredeploy.json
@@ -1,0 +1,939 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "location": {
+            "type": "string"
+        },
+        "networkInterfaceName": {
+            "type": "string"
+        },
+        "subnetName": {
+            "type": "string"
+        },
+        "virtualNetworkId": {
+            "type": "string"
+        },
+        "publicIpAddressName": {
+            "type": "string"
+        },
+        "publicIpAddressType": {
+            "type": "string"
+        },
+        "publicIpAddressSku": {
+            "type": "string"
+        },
+        "virtualMachineName": {
+            "type": "string"
+        },
+        "virtualMachineRG": {
+            "type": "string"
+        },
+        "osDiskType": {
+            "type": "string"
+        },
+        "virtualMachineSize": {
+            "type": "string"
+        },
+        "adminUsername": {
+            "type": "string"
+        },
+        "adminPassword": {
+            "type": "secureString"
+        },
+        "diagnosticsStorageAccountName": {
+            "type": "string"
+        },
+        "diagnosticsStorageAccountId": {
+            "type": "string"
+        },
+        "syslogSASurl": {
+            "type": "string"
+        },
+        "metricsSASurl": {
+            "type": "string"
+        }
+    },
+    "variables": {
+        "vnetId": "[parameters('virtualNetworkId')]",
+        "subnetRef": "[concat(variables('vnetId'), '/subnets/', parameters('subnetName'))]",
+        "diagnosticsExtensionName": "LinuxDiagnostic",
+        "storageAccountSasTokenRequestContent": {
+            "signedServices": "bt",
+            "signedResourceTypes": "co",
+            "signedPermission": "acluw",
+            "signedExpiry": "9001-01-31T05:00:00Z"
+        }
+    },
+    "resources": [
+        {
+            "name": "[parameters('networkInterfaceName')]",
+            "type": "Microsoft.Network/networkInterfaces",
+            "apiVersion": "2019-07-01",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/publicIpAddresses/', parameters('publicIpAddressName'))]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            },
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIpAddress": {
+                                "id": "[resourceId(resourceGroup().name, 'Microsoft.Network/publicIpAddresses', parameters('publicIpAddressName'))]"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "[parameters('publicIpAddressName')]",
+            "type": "Microsoft.Network/publicIpAddresses",
+            "apiVersion": "2019-02-01",
+            "location": "[parameters('location')]",
+            "properties": {
+                "publicIpAllocationMethod": "[parameters('publicIpAddressType')]"
+            },
+            "sku": {
+                "name": "[parameters('publicIpAddressSku')]"
+            }
+        },
+        {
+            "name": "[parameters('virtualMachineName')]",
+            "type": "Microsoft.Compute/virtualMachines",
+            "apiVersion": "2019-07-01",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/networkInterfaces/', parameters('networkInterfaceName'))]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[parameters('virtualMachineSize')]"
+                },
+                "storageProfile": {
+                    "osDisk": {
+                        "createOption": "fromImage",
+                        "managedDisk": {
+                            "storageAccountType": "[parameters('osDiskType')]"
+                        }
+                    },
+                    "imageReference": {
+                        "publisher": "RedHat",
+                        "offer": "RHEL",
+                        "sku": "7.6",
+                        "version": "latest"
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('networkInterfaceName'))]"
+                        }
+                    ]
+                },
+                "osProfile": {
+                    "computerName": "[parameters('virtualMachineName')]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword": "[parameters('adminPassword')]"
+                }
+            }
+        },
+        {
+            "name": "[concat(parameters('virtualMachineName'),'/', variables('diagnosticsExtensionName'))]",
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "apiVersion": "2018-10-01",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Compute/virtualMachines/', parameters('virtualMachineName'))]",
+                "[concat('Microsoft.Compute/virtualMachines/', parameters('virtualMachineName'))]"
+            ],
+            "properties": {
+                "publisher": "Microsoft.Azure.Diagnostics",
+                "type": "LinuxDiagnostic",
+                "typeHandlerVersion": "3.0",
+                "autoUpgradeMinorVersion": true,
+                "settings": {
+                    "StorageAccount": "[parameters('diagnosticsStorageAccountName')]",
+                    "ladCfg": {
+                        "diagnosticMonitorConfiguration": {
+                            "eventVolume": "Medium",
+                            "metrics": {
+                                "metricAggregation": [
+                                    {
+                                        "scheduledTransferPeriod": "PT1M"
+                                    },
+                                    {
+                                        "scheduledTransferPeriod": "PT1H"
+                                    }
+                                ],
+                                "resourceId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/', 'Microsoft.Compute/virtualMachines/', parameters('virtualMachineName'))]"
+                            },
+                            "syslogEvents": {
+                                "sinks": "syslog",
+                                "syslogEventConfiguration": {
+                                    "LOG_AUTH": "LOG_DEBUG",
+                                    "LOG_AUTHPRIV": "LOG_DEBUG",
+                                    "LOG_CRON": "LOG_DEBUG",
+                                    "LOG_DAEMON": "LOG_DEBUG",
+                                    "LOG_FTP": "LOG_DEBUG",
+                                    "LOG_KERN": "LOG_DEBUG",
+                                    "LOG_LOCAL0": "LOG_DEBUG",
+                                    "LOG_LOCAL1": "LOG_DEBUG",
+                                    "LOG_LOCAL2": "LOG_DEBUG",
+                                    "LOG_LOCAL3": "LOG_DEBUG",
+                                    "LOG_LOCAL4": "LOG_DEBUG",
+                                    "LOG_LOCAL5": "LOG_DEBUG",
+                                    "LOG_LOCAL6": "LOG_DEBUG",
+                                    "LOG_LOCAL7": "LOG_DEBUG",
+                                    "LOG_LPR": "LOG_DEBUG",
+                                    "LOG_MAIL": "LOG_DEBUG",
+                                    "LOG_NEWS": "LOG_DEBUG",
+                                    "LOG_SYSLOG": "LOG_DEBUG",
+                                    "LOG_USER": "LOG_DEBUG",
+                                    "LOG_UUCP": "LOG_DEBUG"
+                                }
+                            },
+                            "performanceCounters": {
+                                "sinks": "metrics",
+                                "performanceCounterConfiguration": [
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "CPU IO wait time",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "processor",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "percentiowaittime",
+                                        "counterSpecifier": "/builtin/processor/percentiowaittime",
+                                        "type": "builtin",
+                                        "unit": "Percent",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "CPU user time",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "processor",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "percentusertime",
+                                        "counterSpecifier": "/builtin/processor/percentusertime",
+                                        "type": "builtin",
+                                        "unit": "Percent",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "CPU nice time",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "processor",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "percentnicetime",
+                                        "counterSpecifier": "/builtin/processor/percentnicetime",
+                                        "type": "builtin",
+                                        "unit": "Percent",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "CPU percentage guest OS",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "processor",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "percentprocessortime",
+                                        "counterSpecifier": "/builtin/processor/percentprocessortime",
+                                        "type": "builtin",
+                                        "unit": "Percent",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "CPU interrupt time",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "processor",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "percentinterrupttime",
+                                        "counterSpecifier": "/builtin/processor/percentinterrupttime",
+                                        "type": "builtin",
+                                        "unit": "Percent",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "CPU idle time",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "processor",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "percentidletime",
+                                        "counterSpecifier": "/builtin/processor/percentidletime",
+                                        "type": "builtin",
+                                        "unit": "Percent",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "CPU privileged time",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "processor",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "percentprivilegedtime",
+                                        "counterSpecifier": "/builtin/processor/percentprivilegedtime",
+                                        "type": "builtin",
+                                        "unit": "Percent",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Memory available",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "memory",
+                                        "counter": "availablememory",
+                                        "counterSpecifier": "/builtin/memory/availablememory",
+                                        "type": "builtin",
+                                        "unit": "Bytes",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Swap percent used",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "memory",
+                                        "counter": "percentusedswap",
+                                        "counterSpecifier": "/builtin/memory/percentusedswap",
+                                        "type": "builtin",
+                                        "unit": "Percent",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Memory used",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "memory",
+                                        "counter": "usedmemory",
+                                        "counterSpecifier": "/builtin/memory/usedmemory",
+                                        "type": "builtin",
+                                        "unit": "Bytes",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Page reads",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "memory",
+                                        "counter": "pagesreadpersec",
+                                        "counterSpecifier": "/builtin/memory/pagesreadpersec",
+                                        "type": "builtin",
+                                        "unit": "CountPerSecond",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Swap available",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "memory",
+                                        "counter": "availableswap",
+                                        "counterSpecifier": "/builtin/memory/availableswap",
+                                        "type": "builtin",
+                                        "unit": "Bytes",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Swap percent available",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "memory",
+                                        "counter": "percentavailableswap",
+                                        "counterSpecifier": "/builtin/memory/percentavailableswap",
+                                        "type": "builtin",
+                                        "unit": "Percent",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Mem. percent available",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "memory",
+                                        "counter": "percentavailablememory",
+                                        "counterSpecifier": "/builtin/memory/percentavailablememory",
+                                        "type": "builtin",
+                                        "unit": "Percent",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Pages",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "memory",
+                                        "counter": "pagespersec",
+                                        "counterSpecifier": "/builtin/memory/pagespersec",
+                                        "type": "builtin",
+                                        "unit": "CountPerSecond",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Swap used",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "memory",
+                                        "counter": "usedswap",
+                                        "counterSpecifier": "/builtin/memory/usedswap",
+                                        "type": "builtin",
+                                        "unit": "Bytes",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Memory percentage",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "memory",
+                                        "counter": "percentusedmemory",
+                                        "counterSpecifier": "/builtin/memory/percentusedmemory",
+                                        "type": "builtin",
+                                        "unit": "Percent",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Page writes",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "memory",
+                                        "counter": "pageswrittenpersec",
+                                        "counterSpecifier": "/builtin/memory/pageswrittenpersec",
+                                        "type": "builtin",
+                                        "unit": "CountPerSecond",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Network in guest OS",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "network",
+                                        "counter": "bytesreceived",
+                                        "counterSpecifier": "/builtin/network/bytesreceived",
+                                        "type": "builtin",
+                                        "unit": "Bytes",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Network total bytes",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "network",
+                                        "counter": "bytestotal",
+                                        "counterSpecifier": "/builtin/network/bytestotal",
+                                        "type": "builtin",
+                                        "unit": "Bytes",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Network out guest OS",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "network",
+                                        "counter": "bytestransmitted",
+                                        "counterSpecifier": "/builtin/network/bytestransmitted",
+                                        "type": "builtin",
+                                        "unit": "Bytes",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Network collisions",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "network",
+                                        "counter": "totalcollisions",
+                                        "counterSpecifier": "/builtin/network/totalcollisions",
+                                        "type": "builtin",
+                                        "unit": "Count",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Packets received errors",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "network",
+                                        "counter": "totalrxerrors",
+                                        "counterSpecifier": "/builtin/network/totalrxerrors",
+                                        "type": "builtin",
+                                        "unit": "Count",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Packets sent",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "network",
+                                        "counter": "packetstransmitted",
+                                        "counterSpecifier": "/builtin/network/packetstransmitted",
+                                        "type": "builtin",
+                                        "unit": "Count",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Packets received",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "network",
+                                        "counter": "packetsreceived",
+                                        "counterSpecifier": "/builtin/network/packetsreceived",
+                                        "type": "builtin",
+                                        "unit": "Count",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Packets sent errors",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "network",
+                                        "counter": "totaltxerrors",
+                                        "counterSpecifier": "/builtin/network/totaltxerrors",
+                                        "type": "builtin",
+                                        "unit": "Count",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Filesystem transfers/sec",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "filesystem",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "transferspersecond",
+                                        "counterSpecifier": "/builtin/filesystem/transferspersecond",
+                                        "type": "builtin",
+                                        "unit": "CountPerSecond",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Filesystem % free space",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "filesystem",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "percentfreespace",
+                                        "counterSpecifier": "/builtin/filesystem/percentfreespace",
+                                        "type": "builtin",
+                                        "unit": "Percent",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Filesystem % used space",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "filesystem",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "percentusedspace",
+                                        "counterSpecifier": "/builtin/filesystem/percentusedspace",
+                                        "type": "builtin",
+                                        "unit": "Percent",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Filesystem used space",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "filesystem",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "usedspace",
+                                        "counterSpecifier": "/builtin/filesystem/usedspace",
+                                        "type": "builtin",
+                                        "unit": "Bytes",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Filesystem read bytes/sec",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "filesystem",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "bytesreadpersecond",
+                                        "counterSpecifier": "/builtin/filesystem/bytesreadpersecond",
+                                        "type": "builtin",
+                                        "unit": "CountPerSecond",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Filesystem free space",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "filesystem",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "freespace",
+                                        "counterSpecifier": "/builtin/filesystem/freespace",
+                                        "type": "builtin",
+                                        "unit": "Bytes",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Filesystem % free inodes",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "filesystem",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "percentfreeinodes",
+                                        "counterSpecifier": "/builtin/filesystem/percentfreeinodes",
+                                        "type": "builtin",
+                                        "unit": "Percent",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Filesystem bytes/sec",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "filesystem",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "bytespersecond",
+                                        "counterSpecifier": "/builtin/filesystem/bytespersecond",
+                                        "type": "builtin",
+                                        "unit": "BytesPerSecond",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Filesystem reads/sec",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "filesystem",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "readspersecond",
+                                        "counterSpecifier": "/builtin/filesystem/readspersecond",
+                                        "type": "builtin",
+                                        "unit": "CountPerSecond",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Filesystem write bytes/sec",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "filesystem",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "byteswrittenpersecond",
+                                        "counterSpecifier": "/builtin/filesystem/byteswrittenpersecond",
+                                        "type": "builtin",
+                                        "unit": "CountPerSecond",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Filesystem writes/sec",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "filesystem",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "writespersecond",
+                                        "counterSpecifier": "/builtin/filesystem/writespersecond",
+                                        "type": "builtin",
+                                        "unit": "CountPerSecond",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Filesystem % used inodes",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "filesystem",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "percentusedinodes",
+                                        "counterSpecifier": "/builtin/filesystem/percentusedinodes",
+                                        "type": "builtin",
+                                        "unit": "Percent",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Disk read guest OS",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "disk",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "readbytespersecond",
+                                        "counterSpecifier": "/builtin/disk/readbytespersecond",
+                                        "type": "builtin",
+                                        "unit": "BytesPerSecond",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Disk writes",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "disk",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "writespersecond",
+                                        "counterSpecifier": "/builtin/disk/writespersecond",
+                                        "type": "builtin",
+                                        "unit": "CountPerSecond",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Disk transfer time",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "disk",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "averagetransfertime",
+                                        "counterSpecifier": "/builtin/disk/averagetransfertime",
+                                        "type": "builtin",
+                                        "unit": "Seconds",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Disk transfers",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "disk",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "transferspersecond",
+                                        "counterSpecifier": "/builtin/disk/transferspersecond",
+                                        "type": "builtin",
+                                        "unit": "CountPerSecond",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Disk write guest OS",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "disk",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "writebytespersecond",
+                                        "counterSpecifier": "/builtin/disk/writebytespersecond",
+                                        "type": "builtin",
+                                        "unit": "BytesPerSecond",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Disk read time",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "disk",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "averagereadtime",
+                                        "counterSpecifier": "/builtin/disk/averagereadtime",
+                                        "type": "builtin",
+                                        "unit": "Seconds",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Disk write time",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "disk",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "averagewritetime",
+                                        "counterSpecifier": "/builtin/disk/averagewritetime",
+                                        "type": "builtin",
+                                        "unit": "Seconds",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Disk total bytes",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "disk",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "bytespersecond",
+                                        "counterSpecifier": "/builtin/disk/bytespersecond",
+                                        "type": "builtin",
+                                        "unit": "BytesPerSecond",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Disk reads",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "disk",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "readspersecond",
+                                        "counterSpecifier": "/builtin/disk/readspersecond",
+                                        "type": "builtin",
+                                        "unit": "CountPerSecond",
+                                        "sampleRate": "PT15S"
+                                    },
+                                    {
+                                        "annotation": [
+                                            {
+                                                "displayName": "Disk queue length",
+                                                "locale": "en-us"
+                                            }
+                                        ],
+                                        "class": "disk",
+                                        "condition": "IsAggregate=TRUE",
+                                        "counter": "averagediskqueuelength",
+                                        "counterSpecifier": "/builtin/disk/averagediskqueuelength",
+                                        "type": "builtin",
+                                        "unit": "Count",
+                                        "sampleRate": "PT15S"
+                                    }
+                                ]
+                            }
+                        },
+                        "sampleRateInSeconds": 15
+                    }
+                },
+                "protectedSettings": {
+                    "storageAccountName": "[parameters('diagnosticsStorageAccountName')]",
+                    "storageAccountSasToken": "[ListAccountSas(parameters('diagnosticsStorageAccountId'),'2019-06-01',variables('storageAccountSasTokenRequestContent')).accountSasToken]",
+                    "storageAccountEndPoint": "https://core.windows.net/",
+                    "sinksConfig": {
+                        "sink": [
+                            {
+                                "name": "syslog",
+                                "type": "EventHub",
+                                "sasURL": "[parameters('syslogSASurl')]"
+                            },
+                            {
+                                "name": "metrics",
+                                "type": "EventHub",
+                                "sasURL": "[parameters('metricsSASurl')]"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ],
+    "outputs": {
+        "adminUsername": {
+            "type": "string",
+            "value": "[parameters('adminUsername')]"
+        }
+    }
+}

--- a/Templates/LinuxDiagnosticswithEventHubs/azuredeploy.parameters.json
+++ b/Templates/LinuxDiagnosticswithEventHubs/azuredeploy.parameters.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "location": {
+            "value": "eastus2"
+        },
+        "networkInterfaceName": {
+            "value": "rheldemo001-nic"
+        },
+        "subnetName": {
+            "value": "default"
+        },
+        "virtualNetworkId": {
+            "value": ""
+        },
+        "publicIpAddressName": {
+            "value": "rheldemo001-ip"
+        },
+        "publicIpAddressType": {
+            "value": "Dynamic"
+        },
+        "publicIpAddressSku": {
+            "value": "Basic"
+        },
+        "virtualMachineName": {
+            "value": "rheldemo001"
+        },
+        "virtualMachineRG": {
+            "value": ""
+        },
+        "osDiskType": {
+            "value": "StandardSSD_LRS"
+        },
+        "virtualMachineSize": {
+            "value": "Standard_D2_v3"
+        },
+        "adminUsername": {
+            "value": "vmadmin"
+        },
+        "adminPassword": {
+            "value": ""
+        },
+        "diagnosticsStorageAccountName": {
+            "value": ""
+        },
+        "diagnosticsStorageAccountId": {
+            "value": ""
+        }
+    }
+}

--- a/Templates/LinuxDiagnosticswithEventHubs/deploy.ps1
+++ b/Templates/LinuxDiagnosticswithEventHubs/deploy.ps1
@@ -1,0 +1,58 @@
+param (
+    # Deployment Information:
+    [string]       $ResourceGroupName = "#",
+    [string]       $ResourceLocation = "eastus2",
+    
+    # Event Hub Information:
+    [string]       $EventHubNamespace = "#",
+    [string]       $SyslogEventHubName = "syslog",
+    [string]       $MetricsEventHubName = "metrics",
+    
+    # Event Hub Shared Access Policy Information:
+    [string]       $SyslogAccessPolicyKey = "#",
+    [string]       $MetricsAccessPolicyKey = "#",
+    [string]       $SyslogAccessPolicyName = "#",
+    [string]       $MetricsAccessPolicyName = "#",
+    [int]          $Expiration = 30000 # Token expires now+30000
+)
+
+# Generate Syslog Event Hub SAS URL with Key and Name
+[Reflection.Assembly]::LoadWithPartialName("System.Web")| out-null
+$Syslog_URI= $EventHubNamespace + ".servicebus.windows.net/" + $SyslogEventHubName
+$Syslog_Access_Policy_Name = $SyslogAccessPolicyName
+$Syslog_Access_Policy_Key = $SyslogAccessPolicyKey
+$SyslogExpires=([DateTimeOffset]::Now.ToUnixTimeSeconds())+$Expiration
+$SyslogSignatureString=[System.Web.HttpUtility]::UrlEncode($Syslog_URI)+ "`n" + [string]$SyslogExpires
+$SyslogHMAC = New-Object System.Security.Cryptography.HMACSHA256
+$SyslogHMAC.key = [Text.Encoding]::ASCII.GetBytes($Syslog_Access_Policy_Key)
+$SyslogSignature = $SyslogHMAC.ComputeHash([Text.Encoding]::ASCII.GetBytes($SyslogSignatureString))
+$SyslogSignature = [Convert]::ToBase64String($SyslogSignature)
+$SyslogSASToken = "sr=" + [System.Web.HttpUtility]::UrlEncode($Syslog_URI) + "&sig=" + [System.Web.HttpUtility]::UrlEncode($SyslogSignature) + "&se=" + $SyslogExpires + "&skn=" + $Syslog_Access_Policy_Name
+$SyslogSasURL = "https://" + $Syslog_URI + '?' + $SyslogSASToken
+
+# Generate Metrics Event Hub SAS URL with Key and Name
+[Reflection.Assembly]::LoadWithPartialName("System.Web")| out-null
+$Metrics_URI= $EventHubNamespace + ".servicebus.windows.net/" + $MetricsEventHubName
+$Metrics_Access_Policy_Name = $MetricsAccessPolicyName
+$Metrics_Access_Policy_Key = $MetricsAccessPolicyKey
+$MetricsExpires=([DateTimeOffset]::Now.ToUnixTimeSeconds())+$Expiration
+$MetricsSignatureString=[System.Web.HttpUtility]::UrlEncode($Metrics_URI)+ "`n" + [string]$MetricsExpires
+$MetricsHMAC = New-Object System.Security.Cryptography.HMACSHA256
+$MetricsHMAC.key = [Text.Encoding]::ASCII.GetBytes($Metrics_Access_Policy_Key)
+$MetricsSignature = $MetricsHMAC.ComputeHash([Text.Encoding]::ASCII.GetBytes($MetricsSignatureString))
+$MetricsSignature = [Convert]::ToBase64String($MetricsSignature)
+$MetricsSASToken = "sr=" + [System.Web.HttpUtility]::UrlEncode($Metrics_URI) + "&sig=" + [System.Web.HttpUtility]::UrlEncode($MetricsSignature) + "&se=" + $MetricsExpires + "&skn=" + $Metrics_Access_Policy_Name
+$MetricsSasURL = "https://" + $Metrics_URI + '?' + $MetricsSASToken
+
+$opts = @{
+    Name                  = ("Deployment-{0}-{1}" -f $ResourceGroupName, $(Get-Date).ToString("yyyyMMddhhmmss"))
+    ResourceGroupName     = $ResourceGroupName
+    TemplateFile          = (Join-Path -Path $PWD.Path -ChildPath "azuredeploy.json")
+    TemplateParameterFile = (Join-Path -Path $PWD.Path -ChildPath "azuredeploy.parameters.json")
+    adminPassword         = (Read-Host -Prompt "Enter the administrator password" -AsSecureString)
+    syslogSASurl          = $SyslogSasURL
+    metricsSASurl         = $MetricsSasURL
+}
+
+New-AzResourcegroup -Name $ResourceGroupName -Location $ResourceLocation -Verbose
+New-AzResourceGroupDeployment @opts -Verbose


### PR DESCRIPTION
Here is the Red Hat Enterprise Linux version. Users need to input their Event Hub Namespace and Event Hub keys/policies to successfully stream diagnostic data.

I think some of the networking and VM variables could be cleaned up to match your Windows version, could you walk me through your process on that?